### PR TITLE
Restore state.lineMax after creating table

### DIFF
--- a/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/__tests__/__snapshots__/index.test.js.snap
@@ -134,6 +134,22 @@ exports[`markdown-it-table should be able to parse table with empty list 1`] = `
 </tr>
 <tr>
 <td>
+<p></p>
+</td>
+<td>
+<p></p>
+</td>
+</tr>
+<tr>
+<td>
+<p>.</p>
+</td>
+<td>
+<p></p>
+</td>
+</tr>
+<tr>
+<td>
 <p>content 1</p>
 </td>
 <td>

--- a/src/table.js
+++ b/src/table.js
@@ -205,6 +205,7 @@ module.exports = function table(state, startLine, endLine, silent) {
 
   // token     = state.push('tbody_open', 'tbody', 1);
   token.map = tbodyLines = [startLine + 2, 0];
+  const oldLineMax = state.lineMax;
 
   for (nextLine = startLine + 2; nextLine < endLine; nextLine++) {
     if (state.sCount[nextLine] < state.blkIndent) {
@@ -251,6 +252,7 @@ module.exports = function table(state, startLine, endLine, silent) {
     token = state.push('tr_close', 'tr', -1);
   }
   // token = state.push('tbody_close', 'tbody', -1);
+  state.lineMax = oldLineMax;
   token = state.push('table_close', 'table', -1);
 
   tableLines[1] = tbodyLines[1] = nextLine;


### PR DESCRIPTION
This prevents the browser from crashing on empty list items underneath tables.

Also updated the test snapshot for `markdown-it-table should be able to parse table with empty list ]`, it looks like the previous snapshot was missing table rows.