### PR TITLE
fix: move 'types' field out of exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "node": ">12.6"
   },
   "type": "module",
+  "types": "./typings.d.ts",
   "exports": {
-    "types": "./typings.d.ts",
     "require": "./dist/index.cjs",
     "import": "./dist/index.mjs",
     "default": "./dist/index.cjs"


### PR DESCRIPTION
Typescript uses the `types` or `typings` field to indicate typings, and this was probably accidentally moved inside the `exports` field in 794bcbb4, breaking typescript. This PR moves it to the correct place.